### PR TITLE
Removed switch for better performance

### DIFF
--- a/murmurhash2_gc.js
+++ b/murmurhash2_gc.js
@@ -36,8 +36,8 @@ function murmurhash2_32_gc(str, seed) {
   }
 
   l === 3 && (h ^= (str.charCodeAt(i + 2) & 0xff) << 16);
-  l >= 2 && (h ^= (str.charCodeAt(i + 1) & 0xff) << 8);
-  l >= 1 && (h ^= (str.charCodeAt(i) & 0xff)) && (h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)));
+  l >= 2 && l < 3 && (h ^= (str.charCodeAt(i + 1) & 0xff) << 8);
+  l >= 1 && l < 3 && (h ^= (str.charCodeAt(i) & 0xff)) && (h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)));
 
   h ^= h >>> 13;
   h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));

--- a/murmurhash2_gc.js
+++ b/murmurhash2_gc.js
@@ -35,12 +35,9 @@ function murmurhash2_32_gc(str, seed) {
     ++i;
   }
 
-  switch (l) {
-  case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
-  case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
-  case 1: h ^= (str.charCodeAt(i) & 0xff);
-          h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-  }
+  l === 3 && (h ^= (str.charCodeAt(i + 2) & 0xff) << 16);
+  l >= 2 && (h ^= (str.charCodeAt(i + 1) & 0xff) << 8);
+  l >= 1 && (h ^= (str.charCodeAt(i) & 0xff)) && (h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)));
 
   h ^= h >>> 13;
   h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));


### PR DESCRIPTION
Considering that switches are slower then lookup maps than pure conditional expressions, this PR aims to gain some little performance by replacing the "switch" with pure expressions that produces the same result.